### PR TITLE
PLT-1684: activate granted roles by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
           distribution: temurin
           java-version: 11
 
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Cache sbt
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,26 +41,26 @@ jobs:
           - 3306:3306
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8
 
       - name: Setup Java (temurin@11)
         if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 11
 
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.sbt

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,7 @@
 queue_rules:
   - name: default
-    conditions:
+    merge_method: squash
+    merge_conditions:
       - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@11, mysql:8)
       - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@8, mysql:8)
 
@@ -25,5 +26,4 @@ pull_request_rules:
       - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@8, mysql:8)
     actions:
       queue:
-        method: squash
         name: default

--- a/src/main/scala/com/dwolla/mysql/init/repositories/RoleRepository.scala
+++ b/src/main/scala/com/dwolla/mysql/init/repositories/RoleRepository.scala
@@ -89,8 +89,19 @@ object RoleRepository {
           .flatTap { completion =>
             Logger[ConnectionIO].info(s"added $username to role $role with status $completion")
           }
-          .void
+          .void >> activateDefaultRole(username, role)
       }
+
+    // Granting a role does not activate it (MySQL requires `activate_all_roles_on_login` or
+    // `SET DEFAULT ROLE` for the privileges to take effect at login). Without this, newly
+    // granted users can authenticate but get "Access denied ... to database" errors on every query.
+    private def activateDefaultRole(username: Username, role: RoleName): ConnectionIO[Unit] =
+      RoleQueries.setDefaultRole(username, role)
+        .run
+        .flatTap { completion =>
+          Logger[ConnectionIO].info(s"activated $role as default role for $username with status $completion")
+        }
+        .void
 
     override def removeUserFromRole(username: Username, database: Database): ConnectionIO[Unit] =
       roleNameForDatabase[ConnectionIO](database).flatMap { role =>
@@ -116,6 +127,12 @@ object RoleQueries {
                  role: RoleName)
                 (implicit logHandler: LogHandler): Update0 =
     (fr"REVOKE" ++ Fragment.const(role.value) ++ fr"FROM" ++ Fragment.const(userName.value))
+      .update
+
+  def setDefaultRole(userName: Username,
+                     role: RoleName)
+                    (implicit logHandler: LogHandler): Update0 =
+    (fr"SET DEFAULT ROLE" ++ Fragment.const(role.value) ++ fr"TO" ++ Fragment.const(userName.value))
       .update
 
   // Pretty sure roles and users are stored in the same table


### PR DESCRIPTION
## What

`RoleRepository.addUserToRole` grants a database role to a user (`GRANT <db>_role TO user`) but never activates it. In MySQL 8, a granted role stays dormant until either `SET DEFAULT ROLE` is run for the account, or the server-wide `activate_all_roles_on_login` variable is enabled. Neither happens here, and every RDS instance we checked has `activate_all_roles_on_login=0` (engine default).

Net effect: a newly provisioned user authenticates successfully but gets `Access denied for user '...' to database '...'` (MySQL error 1044) on every query, because their granted role's privileges are never actually active in the session.

## How this was found

`webhook-subscriptions` switched its ECS task to connect as the `webhooks_proxy` user (provisioned by this custom resource as part of the RDS Proxy cutover in PLT-1684). The user authenticated fine but every connection through the proxy failed with:

```
[WARN] The new database connection failed. Error code: [1044]. SQL State: [42000].
Message: Database Access denied for user 'webhooks_proxy'@'%' to database 'webhooks'.
```

This crash-looped the DevInt ECS service. `SHOW GRANTS` for the role association looked correct; the role just wasn't active by default.

## Fix

Run `SET DEFAULT ROLE <role> TO <user>` immediately after `GRANT <role> TO <user>` in `addUserToRole`, so new and updated users have working privileges as soon as the custom resource finishes.

## Testing

- Unit tests pass (`sbt "testOnly * -- --exclude-tags=IntegrationTest"`).
- `RoundTripIntegrationTest` (requires a local MySQL/MariaDB) was not run in this environment, but doesn't currently assert on actual connectivity as the created user, so it wouldn't have caught this class of bug either way. Worth a follow-up to extend it to open a connection as a freshly-created user and run a real query, not just check the GRANT statements succeeded.

## Rollout

Any existing user whose role was granted but never activated (e.g. `webhooks_proxy`, and likely `webhooks_airflow_proxy` in the same stack, provisioned the same way) will need `SET DEFAULT ROLE` run once manually, since this fix only takes effect on the next `addOrUpdateUser`/`addUserToRole` cycle for that user (i.e. next CFN update to the custom resource that includes them).